### PR TITLE
Improve AonsFile init related methods

### DIFF
--- a/test.py
+++ b/test.py
@@ -6,8 +6,8 @@ import aons
 aons_data_file = pathlib.Path(__file__).parent / "data.aons"
 aons_schema_file = pathlib.Path(__file__).parent / "schema.aons"
 
-aons_data = aons.AonsData(aons_data_file)
-aons_schema = aons.AonsSchema(aons_schema_file)
+aons_data = aons.AonsData.from_file(aons_data_file)
+aons_schema = aons.AonsSchema.from_file(aons_schema_file)
 
 # print
 (aons_data.get_dict())


### PR DESCRIPTION
This modified AonsFile in a way that we don't need to fully read the file
 before iterating to get the entries out of it.

AonsFile has only two states now, _enconding and _entries.

Also, classmethods and staticmethods were adopted to clean up the class.